### PR TITLE
allow specifying re-frame update handler as a vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,15 @@ state management function, you can pass the name of the event to be triggered:
  [...]]
 ```
 
-And the library will dispatch ```[:update-state keys new-value]```. If you need to generate more involved events to
+And the library will dispatch ```[:update-state keys new-value]```. If you need to pass extra arguments to the handler,
+specify it as a vector.
+
+```clojure
+[free-form.re-frame/form @values @errors [:update :user]
+ [...]]
+```
+
+If you need to generate more involved events to
 dispatch, you can pass a function that will get the keys and the new value and generate the event to be dispatched. For
 example:
 

--- a/src/cljs/free_form/re_frame.cljs
+++ b/src/cljs/free_form/re_frame.cljs
@@ -7,8 +7,9 @@
 (defn form [values errors event form]
   (let [re-frame-event-generator
         (fn [ks value]
-          (let [event-v (if (fn? event)
-                          (event ks value)
-                          [event ks value])]
+          (let [event-v (cond
+                          (fn? event)     (event ks value)
+                          (vector? event) (conj event ks value)
+                          :else           [event ks value])]
             (re-frame/dispatch event-v)))]
     [core/form values errors re-frame-event-generator form]))


### PR DESCRIPTION
I'd like to have a single `update-form` re-frame handler which is parameterized by the form's path in the `app-db`. This is achievable by passing a function that returns an dispatch vector to `form`, but in most cases the vector will be static (other than the argument injected by `free-form`), so creating a function for it seems to add a bit of unnecessary overhead. This PR allows specifying the dispatch handler as a vector.
