### PR TITLE
Fix checkbox support. Use "checked" instead of "default-checked"

### DIFF
--- a/src/cljs/free_form/core.cljs
+++ b/src/cljs/free_form/core.cljs
@@ -39,7 +39,7 @@
           {:keys [value-on error-on extra-error-keys]} free-form-attributes
           on-change-fn #(on-change keys (extract-event-value %1))
           value-on     (or value-on (case (:type attributes)
-                                      (:checkbox :radio) :default-checked
+                                      (:checkbox :radio) :checked
                                       :value))
           value        (case (:type attributes)
                          :checkbox (= true (get-in values keys))

--- a/test/cljs/free_form/core_test.cljs
+++ b/test/cljs/free_form/core_test.cljs
@@ -195,7 +195,7 @@
                 [:div {}
                  [:input {:type            :checkbox
                           :id              :checkbox
-                          :default-checked false
+                          :checked         false
                           :on-change       :was-function}]
                  [:label {:for :checkbox} "Checkbox"]
                  nil]
@@ -204,21 +204,21 @@
                   [:input {:type            :radio
                            :name            :radio-buttons
                            :value           "radio-option-1"
-                           :default-checked false
+                           :checked         false
                            :on-change       :was-function}]
                   "Radio Option 1"]
                  [:label
                   [:input {:type            :radio
                            :name            :radio-buttons
                            :value           "radio-option-2"
-                           :default-checked false
+                           :checked         false
                            :on-change       :was-function}]
                   "Radio Option 2"]
                  [:label
                   [:input {:type            :radio
                            :name            :radio-buttons
                            :value           "radio-option-3"
-                           :default-checked false
+                           :checked         false
                            :on-change       :was-function}]
                   "Radio Option 3"]
                  nil]
@@ -306,23 +306,23 @@
                 [:div {}
                  [:input {:type            :checkbox
                           :id              :checkbox
-                          :default-checked true
+                          :checked         true
                           :on-change       :was-function}]
                  [:label {:for :checkbox} "Checkbox"] nil]
                 [:div.plain-field {}
                  [:label [:input {:type            :radio
                                   :name            :radio-buttons
                                   :value           "radio-option-1"
-                                  :default-checked false
+                                  :checked         false
                                   :on-change       :was-function}] "Radio Option 1"]
                  [:label [:input {:type            :radio
                                   :name            :radio-buttons
                                   :value           "radio-option-2"
-                                  :default-checked true
+                                  :checked         true
                                   :on-change       :was-function}] "Radio Option 2"]
                  [:label [:input {:type            :radio
                                   :name            :radio-buttons
                                   :value           "radio-option-3"
-                                  :default-checked false
+                                  :checked         false
                                   :on-change       :was-function}] "Radio Option 3"] nil]
                 [:button "Button"]]))))))


### PR DESCRIPTION
I totally forgot to commit/push this and contribute back! Using `:default-checked` wasn't correct - `:checked` should be used to ensure that changes to the form atom are reflected in the form element, just as you use `:value` instead of `:default-value` for other inputs.

Any chance you can merge this and publish as `v0.6.1`?